### PR TITLE
Abstraction refactor  in order to allow for unit testing. (and some implementation of tests)

### DIFF
--- a/pkg/cc/funcs.go
+++ b/pkg/cc/funcs.go
@@ -37,19 +37,19 @@ func ApplyHostname(cfg *config.CloudConfig) error {
 }
 
 func ApplyPassword(cfg *config.CloudConfig) error {
-	return command.SetPassword(cfg.HAOS.Password)
+	return command.SetPassword(cfg.HAOS.Password, command.Concrete{})
 }
 
 func ApplyRuncmd(cfg *config.CloudConfig) error {
-	return command.ExecuteCommand(cfg.Runcmd)
+	return command.ExecuteCommand(cfg.Runcmd, command.Concrete{})
 }
 
 func ApplyBootcmd(cfg *config.CloudConfig) error {
-	return command.ExecuteCommand(cfg.Bootcmd)
+	return command.ExecuteCommand(cfg.Bootcmd, command.Concrete{})
 }
 
 func ApplyInitcmd(cfg *config.CloudConfig) error {
-	return command.ExecuteCommand(cfg.Initcmd)
+	return command.ExecuteCommand(cfg.Initcmd, command.Concrete{})
 }
 
 func ApplyWriteFiles(cfg *config.CloudConfig) error {

--- a/pkg/cc/funcs.go
+++ b/pkg/cc/funcs.go
@@ -25,7 +25,7 @@ import (
 )
 
 func ApplyModules(cfg *config.CloudConfig) error {
-	return module.LoadModules(cfg)
+	return module.LoadModules(cfg, module.Concrete{})
 }
 
 func ApplySysctls(cfg *config.CloudConfig) error {

--- a/pkg/cc/funcs.go
+++ b/pkg/cc/funcs.go
@@ -33,7 +33,7 @@ func ApplySysctls(cfg *config.CloudConfig) error {
 }
 
 func ApplyHostname(cfg *config.CloudConfig) error {
-	return hostname.SetHostname(cfg, hostname.HostnameConcrete{})
+	return hostname.SetHostname(cfg, hostname.Concrete{})
 }
 
 func ApplyPassword(cfg *config.CloudConfig) error {

--- a/pkg/cc/funcs.go
+++ b/pkg/cc/funcs.go
@@ -33,7 +33,7 @@ func ApplySysctls(cfg *config.CloudConfig) error {
 }
 
 func ApplyHostname(cfg *config.CloudConfig) error {
-	return hostname.SetHostname(cfg)
+	return hostname.SetHostname(cfg, hostname.HostnameConcrete{})
 }
 
 func ApplyPassword(cfg *config.CloudConfig) error {

--- a/pkg/cc/funcs.go
+++ b/pkg/cc/funcs.go
@@ -25,7 +25,7 @@ import (
 )
 
 func ApplyModules(cfg *config.CloudConfig) error {
-	return module.LoadModules(cfg, module.Concrete{})
+	return module.LoadModules(cfg)
 }
 
 func ApplySysctls(cfg *config.CloudConfig) error {

--- a/pkg/cc/funcs.go
+++ b/pkg/cc/funcs.go
@@ -37,19 +37,19 @@ func ApplyHostname(cfg *config.CloudConfig) error {
 }
 
 func ApplyPassword(cfg *config.CloudConfig) error {
-	return command.SetPassword(cfg.HAOS.Password, command.Concrete{})
+	return command.SetPassword(cfg.HAOS.Password)
 }
 
 func ApplyRuncmd(cfg *config.CloudConfig) error {
-	return command.ExecuteCommand(cfg.Runcmd, command.Concrete{})
+	return command.ExecuteCommand(cfg.Runcmd)
 }
 
 func ApplyBootcmd(cfg *config.CloudConfig) error {
-	return command.ExecuteCommand(cfg.Bootcmd, command.Concrete{})
+	return command.ExecuteCommand(cfg.Bootcmd)
 }
 
 func ApplyInitcmd(cfg *config.CloudConfig) error {
-	return command.ExecuteCommand(cfg.Initcmd, command.Concrete{})
+	return command.ExecuteCommand(cfg.Initcmd)
 }
 
 func ApplyWriteFiles(cfg *config.CloudConfig) error {

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -10,17 +10,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type Abstract interface {
+type abstract interface {
 	Command(name string, arg ...string) *exec.Cmd
 }
 
-type Concrete struct{}
+type concrete struct{}
 
-func (Concrete) Command(name string, arg ...string) *exec.Cmd {
+func (concrete) Command(name string, arg ...string) *exec.Cmd {
 	return exec.Command(name, arg...)
 }
 
-var impl Abstract = Concrete{}
+var impl abstract = concrete{}
 
 func ExecuteCommand(commands []string) error {
 	for _, cmd := range commands {

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -20,10 +20,12 @@ func (Concrete) Command(name string, arg ...string) *exec.Cmd {
 	return exec.Command(name, arg...)
 }
 
-func ExecuteCommand(commands []string, c Abstract) error {
+var impl Abstract = Concrete{}
+
+func ExecuteCommand(commands []string) error {
 	for _, cmd := range commands {
 		logrus.Debugf("running cmd `%s`", cmd)
-		ce := exec.Command("sh", "-c", cmd)
+		ce := impl.Command("sh", "-c", cmd)
 		ce.Stdout = os.Stdout
 		ce.Stderr = os.Stderr
 		if err := ce.Run(); err != nil {
@@ -33,11 +35,11 @@ func ExecuteCommand(commands []string, c Abstract) error {
 	return nil
 }
 
-func SetPassword(password string, c Abstract) error {
+func SetPassword(password string) error {
 	if password == "" {
 		return nil
 	}
-	cmd := c.Command("chpasswd")
+	cmd := impl.Command("chpasswd")
 	if strings.HasPrefix(password, "$") {
 		cmd.Args = append(cmd.Args, "-e")
 	}

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -1,0 +1,26 @@
+package command
+
+import (
+	"os/exec"
+	"testing"
+)
+
+type Mock struct{}
+
+func (Mock) Command(name string, arg ...string) *exec.Cmd {
+	return exec.Command("echo", "mock")
+}
+
+func TestExecuteCommand(t *testing.T) {
+	err := ExecuteCommand([]string{"echo"}, Mock{})
+	if err != nil {
+		t.Errorf("failed to execute command: %v", err)
+	}
+}
+
+func TestSetPassword(t *testing.T) {
+	err := SetPassword("mock", Mock{})
+	if err != nil {
+		t.Errorf("failed to set password: %v", err)
+	}
+}

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -12,14 +12,16 @@ func (Mock) Command(name string, arg ...string) *exec.Cmd {
 }
 
 func TestExecuteCommand(t *testing.T) {
-	err := ExecuteCommand([]string{"echo"}, Mock{})
+	impl = Mock{}
+	err := ExecuteCommand([]string{"echo"})
 	if err != nil {
 		t.Errorf("failed to execute command: %v", err)
 	}
 }
 
 func TestSetPassword(t *testing.T) {
-	err := SetPassword("mock", Mock{})
+	impl = Mock{}
+	err := SetPassword("mock")
 	if err != nil {
 		t.Errorf("failed to set password: %v", err)
 	}

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 )
 
-type Mock struct{}
+type mock struct{}
 
-func (Mock) Command(name string, arg ...string) *exec.Cmd {
+func (mock) Command(name string, arg ...string) *exec.Cmd {
 	return exec.Command("echo", "mock")
 }
 
 func TestExecuteCommand(t *testing.T) {
-	impl = Mock{}
+	impl = mock{}
 	err := ExecuteCommand([]string{"echo"})
 	if err != nil {
 		t.Errorf("failed to execute command: %v", err)
@@ -20,7 +20,7 @@ func TestExecuteCommand(t *testing.T) {
 }
 
 func TestSetPassword(t *testing.T) {
-	impl = Mock{}
+	impl = mock{}
 	err := SetPassword("mock")
 	if err != nil {
 		t.Errorf("failed to set password: %v", err)

--- a/pkg/hostname/hostname.go
+++ b/pkg/hostname/hostname.go
@@ -10,7 +10,7 @@ import (
 	"github.com/1898andCo/HAOS/pkg/config"
 )
 
-type HostnameAbstract interface {
+type Abstract interface {
 	Sethostname([]byte) error
 	Hostname() (string, error)
 	Open(string) (*os.File, error)
@@ -18,29 +18,29 @@ type HostnameAbstract interface {
 	WriteFile(string, []byte, os.FileMode) error
 }
 
-type HostnameConcrete struct{}
+type Concrete struct{}
 
-func (HostnameConcrete) Sethostname(hostname []byte) error {
+func (Concrete) Sethostname(hostname []byte) error {
 	return syscall.Sethostname(hostname)
 }
 
-func (HostnameConcrete) Hostname() (string, error) {
+func (Concrete) Hostname() (string, error) {
 	return os.Hostname()
 }
 
-func (HostnameConcrete) Open(path string) (*os.File, error) {
+func (Concrete) Open(path string) (*os.File, error) {
 	return os.Open(path)
 }
 
-func (HostnameConcrete) Close(file *os.File) error {
+func (Concrete) Close(file *os.File) error {
 	return file.Close()
 }
 
-func (HostnameConcrete) WriteFile(path string, data []byte, perm os.FileMode) error {
+func (Concrete) WriteFile(path string, data []byte, perm os.FileMode) error {
 	return ioutil.WriteFile(path, data, perm)
 }
 
-func SetHostname(c *config.CloudConfig, call HostnameAbstract) error {
+func SetHostname(c *config.CloudConfig, call Abstract) error {
 	hostname := c.Hostname
 	if hostname == "" {
 		return nil
@@ -51,7 +51,7 @@ func SetHostname(c *config.CloudConfig, call HostnameAbstract) error {
 	return syncHostname(call)
 }
 
-func syncHostname(h HostnameAbstract) error {
+func syncHostname(h Abstract) error {
 	hostname, err := h.Hostname()
 	if err != nil {
 		return err

--- a/pkg/hostname/hostname.go
+++ b/pkg/hostname/hostname.go
@@ -10,7 +10,7 @@ import (
 	"github.com/1898andCo/HAOS/pkg/config"
 )
 
-type Abstract interface {
+type abstract interface {
 	Sethostname([]byte) error
 	Hostname() (string, error)
 	Open(string) (*os.File, error)
@@ -40,7 +40,7 @@ func (Concrete) WriteFile(path string, data []byte, perm os.FileMode) error {
 	return ioutil.WriteFile(path, data, perm)
 }
 
-func SetHostname(c *config.CloudConfig, call Abstract) error {
+func SetHostname(c *config.CloudConfig, call abstract) error {
 	hostname := c.Hostname
 	if hostname == "" {
 		return nil
@@ -51,7 +51,7 @@ func SetHostname(c *config.CloudConfig, call Abstract) error {
 	return syncHostname(call)
 }
 
-func syncHostname(h Abstract) error {
+func syncHostname(h abstract) error {
 	hostname, err := h.Hostname()
 	if err != nil {
 		return err

--- a/pkg/hostname/hostname_test.go
+++ b/pkg/hostname/hostname_test.go
@@ -7,23 +7,23 @@ import (
 	"github.com/1898andCo/HAOS/pkg/config"
 )
 
-type Mock struct {
+type mock struct {
 	SethostnameFunc func([]byte) error
 }
 
-func (Mock) Sethostname(hostname []byte) error {
+func (mock) Sethostname(hostname []byte) error {
 	return nil
 }
 
-func (Mock) Hostname() (string, error) {
+func (mock) Hostname() (string, error) {
 	return "test", nil
 }
 
-func (Mock) Close(file *os.File) error {
+func (mock) Close(file *os.File) error {
 	return file.Close()
 }
 
-func (Mock) WriteFile(path string, data []byte, perm os.FileMode) error {
+func (mock) WriteFile(path string, data []byte, perm os.FileMode) error {
 	return nil
 }
 
@@ -33,7 +33,7 @@ const hostsFilecontent (string) = `127.0.1.1
 
 const hostnameFilecontent (string) = `test`
 
-func (Mock) Open(path string) (*os.File, error) {
+func (mock) Open(path string) (*os.File, error) {
 	file := os.NewFile(0, "test")
 	file.WriteString(hostsFilecontent)
 	return file, nil
@@ -43,7 +43,7 @@ func TestSetHostname(t *testing.T) {
 	c := &config.CloudConfig{
 		Hostname: "test",
 	}
-	call := &Mock{}
+	call := &mock{}
 	err := SetHostname(c, call)
 	if err != nil {
 		t.Errorf("Expected nil, got %v", err)

--- a/pkg/hostname/hostname_test.go
+++ b/pkg/hostname/hostname_test.go
@@ -7,23 +7,23 @@ import (
 	"github.com/1898andCo/HAOS/pkg/config"
 )
 
-type HostnameMock struct {
+type Mock struct {
 	SethostnameFunc func([]byte) error
 }
 
-func (HostnameMock) Sethostname(hostname []byte) error {
+func (Mock) Sethostname(hostname []byte) error {
 	return nil
 }
 
-func (HostnameMock) Hostname() (string, error) {
+func (Mock) Hostname() (string, error) {
 	return "test", nil
 }
 
-func (HostnameMock) Close(file *os.File) error {
+func (Mock) Close(file *os.File) error {
 	return file.Close()
 }
 
-func (HostnameMock) WriteFile(path string, data []byte, perm os.FileMode) error {
+func (Mock) WriteFile(path string, data []byte, perm os.FileMode) error {
 	return nil
 }
 
@@ -33,9 +33,9 @@ const hostsFilecontent (string) = `127.0.1.1
 
 const hostnameFilecontent (string) = `test`
 
-func (HostnameMock) Open(path string) (*os.File, error) {
+func (Mock) Open(path string) (*os.File, error) {
 	file := os.NewFile(0, "test")
-	file.WriteString(hostnameFilecontent)
+	file.WriteString(hostsFilecontent)
 	return file, nil
 }
 
@@ -43,7 +43,7 @@ func TestSetHostname(t *testing.T) {
 	c := &config.CloudConfig{
 		Hostname: "test",
 	}
-	call := &HostnameMock{}
+	call := &Mock{}
 	err := SetHostname(c, call)
 	if err != nil {
 		t.Errorf("Expected nil, got %v", err)

--- a/pkg/hostname/hostname_test.go
+++ b/pkg/hostname/hostname_test.go
@@ -1,0 +1,51 @@
+package hostname
+
+import (
+	"os"
+	"testing"
+
+	"github.com/1898andCo/HAOS/pkg/config"
+)
+
+type HostnameMock struct {
+	SethostnameFunc func([]byte) error
+}
+
+func (HostnameMock) Sethostname(hostname []byte) error {
+	return nil
+}
+
+func (HostnameMock) Hostname() (string, error) {
+	return "test", nil
+}
+
+func (HostnameMock) Close(file *os.File) error {
+	return file.Close()
+}
+
+func (HostnameMock) WriteFile(path string, data []byte, perm os.FileMode) error {
+	return nil
+}
+
+const hostsFilecontent (string) = `127.0.1.1
+127.0.0.1
+0.0.0.0`
+
+const hostnameFilecontent (string) = `test`
+
+func (HostnameMock) Open(path string) (*os.File, error) {
+	file := os.NewFile(0, "test")
+	file.WriteString(hostnameFilecontent)
+	return file, nil
+}
+
+func TestSetHostname(t *testing.T) {
+	c := &config.CloudConfig{
+		Hostname: "test",
+	}
+	call := &HostnameMock{}
+	err := SetHostname(c, call)
+	if err != nil {
+		t.Errorf("Expected nil, got %v", err)
+	}
+}

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -14,14 +14,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type Abstract interface {
+type abstract interface {
 	Get(string) (*http.Response, error)
 	WriteFile(string, []byte, os.FileMode) error
 }
 
-type Concrete struct{}
+type concrete struct{}
 
-func (Concrete) Get(url string) (*http.Response, error) {
+func (concrete) Get(url string) (*http.Response, error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to download manifest URL")
@@ -29,11 +29,11 @@ func (Concrete) Get(url string) (*http.Response, error) {
 	return resp, nil
 }
 
-func (Concrete) WriteFile(path string, data []byte, perm os.FileMode) error {
+func (concrete) WriteFile(path string, data []byte, perm os.FileMode) error {
 	return ioutil.WriteFile(path, data, perm)
 }
 
-var impl Abstract = Concrete{}
+var impl abstract = concrete{}
 
 const (
 	retryMax     = 5

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1,0 +1,60 @@
+package manifests
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/1898andCo/HAOS/pkg/config"
+)
+
+type Mock struct{}
+
+func (Mock) Get(url string) (*http.Response, error) {
+	stringReader := strings.NewReader("this is the body")
+	stringReadCloser := io.NopCloser(stringReader)
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Body:          stringReadCloser,
+		ContentLength: stringReader.Size(),
+	}, nil
+}
+
+var mockData = []byte("")
+
+func (Mock) WriteFile(path string, data []byte, perm os.FileMode) error {
+	mockData = data
+	return nil
+}
+
+type MockError struct{}
+
+func (MockError) Get(url string) (*http.Response, error) {
+	stringReader := strings.NewReader("")
+	stringReadCloser := io.NopCloser(stringReader)
+	return &http.Response{
+		StatusCode:    http.StatusInternalServerError,
+		Body:          stringReadCloser,
+		ContentLength: stringReader.Size(),
+	}, nil
+}
+
+func TestApplyBootManifests(t *testing.T) {
+	manifest := config.Manifest{
+		URL:    "localhost",
+		SHA256: "",
+	}
+	impl = Mock{}
+	cfg := &config.CloudConfig{
+		BootManifests: []config.Manifest{manifest},
+	}
+	err := ApplyBootManifests(cfg)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if string(mockData) != "this is the body" {
+		t.Errorf("expected %s, got %s", "this is the body", string(mockData))
+	}
+}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/1898andCo/HAOS/pkg/config"
 )
 
-type Mock struct{}
+type mock struct{}
 
-func (Mock) Get(url string) (*http.Response, error) {
+func (mock) Get(url string) (*http.Response, error) {
 	stringReader := strings.NewReader("this is the body")
 	stringReadCloser := io.NopCloser(stringReader)
 	return &http.Response{
@@ -24,14 +24,14 @@ func (Mock) Get(url string) (*http.Response, error) {
 
 var mockData = []byte("")
 
-func (Mock) WriteFile(path string, data []byte, perm os.FileMode) error {
+func (mock) WriteFile(path string, data []byte, perm os.FileMode) error {
 	mockData = data
 	return nil
 }
 
-type MockError struct{}
+type mockError struct{}
 
-func (MockError) Get(url string) (*http.Response, error) {
+func (mockError) Get(url string) (*http.Response, error) {
 	stringReader := strings.NewReader("")
 	stringReadCloser := io.NopCloser(stringReader)
 	return &http.Response{
@@ -46,7 +46,7 @@ func TestApplyBootManifests(t *testing.T) {
 		URL:    "localhost",
 		SHA256: "",
 	}
-	impl = Mock{}
+	impl = mock{}
 	cfg := &config.CloudConfig{
 		BootManifests: []config.Manifest{manifest},
 	}

--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -15,31 +15,35 @@ const (
 	procModulesFile = "/proc/modules"
 )
 
-type Abstract interface {
+type abstract interface {
 	Open(string) (*os.File, error)
 	Close(*os.File) error
 	Load(string, string) error
 }
 
-type Concrete struct{}
+type concrete struct{}
 
-func (Concrete) Open(name string) (*os.File, error) {
+func (concrete) Open(name string) (*os.File, error) {
 	return os.Open(name)
 }
 
-func (Concrete) Close(f *os.File) error {
+func (concrete) Close(f *os.File) error {
 	return f.Close()
 }
-func (Concrete) Load(module, params string) error {
+
+func (concrete) Load(module, params string) error {
 	return modprobe.Load(module, params)
 }
-func LoadModules(cfg *config.CloudConfig, m Abstract) error {
+
+var impl abstract = concrete{}
+
+func LoadModules(cfg *config.CloudConfig) error {
 	loaded := map[string]bool{}
-	f, err := m.Open(procModulesFile)
+	f, err := impl.Open(procModulesFile)
 	if err != nil {
 		return err
 	}
-	defer m.Close(f)
+	defer impl.Close(f)
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
 		loaded[strings.SplitN(sc.Text(), " ", 2)[0]] = true

--- a/pkg/module/module_test.go
+++ b/pkg/module/module_test.go
@@ -7,17 +7,17 @@ import (
 	"github.com/1898andCo/HAOS/pkg/config"
 )
 
-type Mock struct{}
+type mock struct{}
 
-func (Mock) Open(name string) (*os.File, error) {
+func (mock) Open(name string) (*os.File, error) {
 	return os.NewFile(0, "mock"), nil
 }
 
-func (Mock) Load(module, params string) error {
+func (mock) Load(module, params string) error {
 	return nil
 }
 
-func (Mock) Close(f *os.File) error {
+func (mock) Close(f *os.File) error {
 	err := f.Close()
 	if err != nil {
 		return err
@@ -26,8 +26,8 @@ func (Mock) Close(f *os.File) error {
 }
 
 func TestModule(t *testing.T) {
-	m := Mock{}
-	err := LoadModules(&config.CloudConfig{HAOS: config.HAOS{Modules: []string{}}}, m)
+	impl = mock{}
+	err := LoadModules(&config.CloudConfig{HAOS: config.HAOS{Modules: []string{}}})
 	if err != nil {
 		t.Errorf("failed to load modules: %v", err)
 	}

--- a/pkg/module/module_test.go
+++ b/pkg/module/module_test.go
@@ -1,0 +1,34 @@
+package module
+
+import (
+	"os"
+	"testing"
+
+	"github.com/1898andCo/HAOS/pkg/config"
+)
+
+type Mock struct{}
+
+func (Mock) Open(name string) (*os.File, error) {
+	return os.NewFile(0, "mock"), nil
+}
+
+func (Mock) Load(module, params string) error {
+	return nil
+}
+
+func (Mock) Close(f *os.File) error {
+	err := f.Close()
+	if err != nil {
+		return err
+	}
+	return os.Remove(f.Name())
+}
+
+func TestModule(t *testing.T) {
+	m := Mock{}
+	err := LoadModules(&config.CloudConfig{HAOS: config.HAOS{Modules: []string{}}}, m)
+	if err != nil {
+		t.Errorf("failed to load modules: %v", err)
+	}
+}

--- a/pkg/questions/questions.go
+++ b/pkg/questions/questions.go
@@ -10,17 +10,17 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
-type Abstract interface {
+type abstract interface {
 	Stdin() *bufio.Reader
 }
 
-type Concrete struct{}
+type concrete struct{}
 
-func (Concrete) Stdin() *bufio.Reader {
+func (concrete) Stdin() *bufio.Reader {
 	return bufio.NewReader(os.Stdin)
 }
 
-var impl Abstract = Concrete{}
+var impl abstract = concrete{}
 
 func PromptFormattedOptions(text string, def int, options ...string) (int, error) {
 	var newOptions []string

--- a/pkg/questions/questions.go
+++ b/pkg/questions/questions.go
@@ -10,6 +10,18 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
+type Abstract interface {
+	Stdin() *bufio.Reader
+}
+
+type Concrete struct{}
+
+func (Concrete) Stdin() *bufio.Reader {
+	return bufio.NewReader(os.Stdin)
+}
+
+var impl Abstract = Concrete{}
+
 func PromptFormattedOptions(text string, def int, options ...string) (int, error) {
 	var newOptions []string
 	for i := range options {
@@ -106,7 +118,7 @@ func PrintfToTerm(msg string, format ...interface{}) {
 func Prompt(text, def string) (string, error) {
 	for {
 		PrintToTerm(text)
-		answer, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		answer, err := bufio.NewReader(impl.Stdin()).ReadString('\n')
 		if err != nil {
 			return "", err
 		}
@@ -127,7 +139,7 @@ func Prompt(text, def string) (string, error) {
 func PromptOptional(text, def string) (string, error) {
 	for {
 		PrintToTerm(text)
-		answer, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		answer, err := bufio.NewReader(impl.Stdin()).ReadString('\n')
 		if err != nil {
 			return "", err
 		}

--- a/pkg/questions/questions_test.go
+++ b/pkg/questions/questions_test.go
@@ -1,0 +1,59 @@
+package questions
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+type MockBool struct{}
+
+func (MockBool) Stdin() *bufio.Reader {
+	return bufio.NewReader(bytes.NewBufferString("y\n"))
+}
+
+type MockBlank struct{}
+
+func (MockBlank) Stdin() *bufio.Reader {
+	return bufio.NewReader(bytes.NewBufferString(" \n"))
+}
+
+func TestPrompt(t *testing.T) {
+	impl = MockBool{}
+	ans, err := Prompt("Enter y: ", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ans != "y" {
+		t.Fatalf("expected y, got %s", ans)
+	}
+	fmt.Println(ans)
+
+}
+
+func TestPromptBool(t *testing.T) {
+	impl = MockBool{}
+	ans, err := PromptBool("Enter y: ", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ans {
+		t.Fatalf("expected true, got %t", ans)
+	}
+	fmt.Println(ans)
+
+}
+
+func TestPromptOptional(t *testing.T) {
+	impl = MockBlank{}
+	ans, err := PromptOptional("Enter something: ", "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ans != "default" {
+		t.Fatalf("expected 'default', got %s", ans)
+	}
+	fmt.Println(ans)
+
+}

--- a/pkg/questions/questions_test.go
+++ b/pkg/questions/questions_test.go
@@ -7,20 +7,20 @@ import (
 	"testing"
 )
 
-type MockBool struct{}
+type mockBool struct{}
 
-func (MockBool) Stdin() *bufio.Reader {
+func (mockBool) Stdin() *bufio.Reader {
 	return bufio.NewReader(bytes.NewBufferString("y\n"))
 }
 
-type MockBlank struct{}
+type mockBlank struct{}
 
-func (MockBlank) Stdin() *bufio.Reader {
+func (mockBlank) Stdin() *bufio.Reader {
 	return bufio.NewReader(bytes.NewBufferString(" \n"))
 }
 
 func TestPrompt(t *testing.T) {
-	impl = MockBool{}
+	impl = mockBool{}
 	ans, err := Prompt("Enter y: ", "")
 	if err != nil {
 		t.Fatal(err)
@@ -33,7 +33,7 @@ func TestPrompt(t *testing.T) {
 }
 
 func TestPromptBool(t *testing.T) {
-	impl = MockBool{}
+	impl = mockBool{}
 	ans, err := PromptBool("Enter y: ", false)
 	if err != nil {
 		t.Fatal(err)
@@ -46,7 +46,7 @@ func TestPromptBool(t *testing.T) {
 }
 
 func TestPromptOptional(t *testing.T) {
-	impl = MockBlank{}
+	impl = mockBlank{}
 	ans, err := PromptOptional("Enter something: ", "default")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
What:
Test files for various packages in the golang code which sets up the install
Why:
To improve testing coverage (or to create the ability to test)
How:
Interfaces implemented to allow for both a base and a mock implementation. Interfaces are private to the package and not exported. The base implementation is the same as before the refactoring.
The mock implementations handle side effects, such as opening a file, or setting an environment variable, with various in-memory stubs, allowing for testing of the code surrounding the low-level system calls.
More tests can be implemented with some failure states, this is not yet done. (for example, a mock would be created that would explicitly return a specific error from an attempted os.Open or equivalent)
