### PR TITLE
MSSCI-17238 Migrate workflows from ARC v1 to v2 runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Release
-    runs-on: self-hosted 
+    runs-on: [build-deploy, Common, X64] 
     steps:
 
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## Why
Migrating from EOL Summerwind ARC v1 runners to ARC v2.

## What
1 workflow files migrated. Secrets-using workflows → build-deploy. No-secrets workflows → build-sandbox.

**Draft:** build-deploy jobs will be stuck until infra PR #2995 (runner group allowlist) is merged and Spacelift applied.

## Refs
- MSSCI-17238
- MSSCI-5880 (parent)
- Depends on: infra PR #2995