### PR TITLE
MSSCI-17323 chore(actions): set least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/convert-todo-to-issue.yml
+++ b/.github/workflows/convert-todo-to-issue.yml
@@ -4,6 +4,8 @@ on:
     workflow_dispatch:
 
 permissions:
+  contents: read
+  issues: write
 
 jobs:
   todo:              

--- a/.github/workflows/convert-todo-to-issue.yml
+++ b/.github/workflows/convert-todo-to-issue.yml
@@ -3,6 +3,8 @@ on:
     push:
     workflow_dispatch:
 
+permissions:
+
 jobs:
   todo:              
     runs-on: ubuntu-latest  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - 'v*'
 
+permissions:
+
 jobs:
   build:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - 'v*'
 
 permissions:
+  contents: write
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Add explicit `permissions:` block(s) to workflow file(s) that previously ran with GitHub's default-permissive `GITHUB_TOKEN`. Each block grants only the scopes the workflow actually requires.

This is part of MSSCI-17317 (epic: Tighten GITHUB_TOKEN permissions across org workflows). step-security flagged this repo and its auto-fix-PR run failed; this is the manual remediation.

## Test plan

- [ ] Workflow run on this PR completes successfully (no permission-denied failures from the new block)

Refs: MSSCI-17323